### PR TITLE
Improve macos build times

### DIFF
--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,5 @@
 platform :osx, '10.12'
+$FirebaseSDKVersion = '7.4.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -29,6 +30,8 @@ flutter_macos_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
+
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '7.4.0'
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
 end


### PR DESCRIPTION
Override Firebase SDK & download prebuilt binary

- seems to be the way it's done for now (see https://github.com/FirebaseExtended/flutterfire/pull/4698)
- we probbaly should keep track of needing to remove this when the plugins
catch up, can I leave that for you to add as a task somewhere?  Are you using github issues?