### PR TITLE
Small clean up and layout strategy change

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -28,9 +28,6 @@ jobs:
       with:
         channel: beta
 
-    # enable Flutter for web
-    - run: flutter config --enable-web
-
     # get app dependencies
     - run: flutter pub get
 

--- a/lib/UI/components/header.dart
+++ b/lib/UI/components/header.dart
@@ -15,45 +15,43 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        SizedBox(height: 5),
         SizedBox(
-          height: 10,
-        ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            Flexible(child: Container()),
-            Flexible(
-              flex: 8,
-              child: Row(
-                children: [
-                  LogoNavWidget(),
-                  SizedBox(width: 20),
-                  NavRailButtons(),
-                  Expanded(
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        FindASealButton(),
-                        SizedBox(width: 20),
-                        ReportASightingWidget(),
-                      ],
+          height: 60,
+          child: Row(
+            children: [
+              Spacer(),
+              Flexible(
+                flex: 8,
+                child: Row(
+                  children: [
+                    LogoNavWidget(),
+                    SizedBox(width: 20),
+                    NavRailButtons(),
+                    Expanded(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          FindASealButton(),
+                          SizedBox(width: 20),
+                          ReportASightingWidget(),
+                        ],
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            Flexible(child: Container()),
-          ],
+              Spacer(),
+            ],
+          ),
         ),
-        Divider(
-          color: Colors.blue,
-        ),
+        Divider(color: Colors.blue),
       ],
     );
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(74);
+  Size get preferredSize => const Size.fromHeight(94);
 }
 
 class LogoNavWidget extends StatelessWidget {
@@ -69,6 +67,7 @@ class LogoNavWidget extends StatelessWidget {
       },
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
           const Text(
             'Hawaiian',
@@ -159,28 +158,6 @@ class FindASealButton extends StatelessWidget {
   }
 }
 
-// class ReportASightingWidget extends StatelessWidget {
-//   const ReportASightingWidget({
-//     Key? key,
-//   }) : super(key: key);
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return Column(
-//       mainAxisAlignment: MainAxisAlignment.end,
-//       children: [
-//         Text('Report a sighting'),
-//         Text(
-//           '(888) 256-9840',
-//           style: TextStyle(
-//             fontWeight: FontWeight.bold,
-//           ),
-//         ),
-//       ],
-//     );
-//   }
-// }
-
 class ReportASightingWidget extends StatelessWidget {
   const ReportASightingWidget({
     Key? key,
@@ -191,7 +168,7 @@ class ReportASightingWidget extends StatelessWidget {
     return TextButton(
         onPressed: () {},
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.end,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text('Report a sighting'),
             Text(

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,1 +1,1 @@
-const int smallScreenWitdth = 650;
+const int smallScreenWidth = 650;

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,0 +1,1 @@
+const int smallScreenWitdth = 650;


### PR DESCRIPTION
Hey mate!  Putting this up for discussion - changed to a layout strategy where the header decides it's size and the children use the boundaries to find their place rather than fitting things in the available space - it seems like less fiddling when you want to change things.  

I'm not sure if it's better so wanted to discuss - the end result was more white space (and seemed OK so I left it) but that wasn't the purpose, the purpose was to change where the dial lives that you would turn to change the overall layout.  

Hope that makes sense! 